### PR TITLE
Implement compact UI with reduced spacing and smaller fonts

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -50,10 +50,10 @@ export function Header() {
   }, [isLoading, setLoading])
 
   return (
-    <header className="bg-white border-b border-gray-200 px-6 py-4">
+    <header className="bg-white border-b border-gray-200 px-4 py-2">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <h1 className="text-2xl font-bold text-gray-900">PAN-OS Configuration Viewer</h1>
+        <div className="flex items-center gap-3">
+          <h1 className="text-base font-bold text-gray-900">PAN-OS Configuration Viewer</h1>
           
           <Select
             value={selectedConfig?.name || ''}
@@ -94,7 +94,7 @@ export function Header() {
               }, 50)
             }}
           >
-            <SelectTrigger className="w-[300px]">
+            <SelectTrigger className="w-[250px] h-8 text-xs">
               <SelectValue placeholder="Select a configuration" />
             </SelectTrigger>
             <SelectContent>
@@ -112,14 +112,14 @@ export function Header() {
             onClick={() => refetch()}
             disabled={isLoading}
           >
-            <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} />
+            <RefreshCw className={cn("h-3 w-3", isLoading && "animate-spin")} />
           </Button>
         </div>
 
         {selectedConfig && (
-          <div className="text-sm text-gray-500">
+          <div className="text-xs text-gray-500">
             <span>Size: {(selectedConfig.size / 1024 / 1024).toFixed(2)} MB</span>
-            <span className="ml-4">Modified: {new Date(selectedConfig.modified).toLocaleDateString()}</span>
+            <span className="ml-3">Modified: {new Date(selectedConfig.modified).toLocaleDateString()}</span>
           </div>
         )}
       </div>

--- a/frontend/src/components/layout/MainContent.tsx
+++ b/frontend/src/components/layout/MainContent.tsx
@@ -45,7 +45,7 @@ export function MainContent() {
   }
 
   return (
-    <div className="p-6">
+    <div className="p-3">
       {renderContent()}
     </div>
   )

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -101,7 +101,7 @@ export function Sidebar({ isOpen, onToggle }: SidebarProps) {
             </button>
             
             {isOpen && showSecurityProfiles && (
-              <ul className="ml-8 mt-2 space-y-1">
+              <ul className="ml-6 mt-1 space-y-0.5">
                 {securityProfiles.map((profile) => {
                   const isActive = activeSection === `security-profile-${profile.id}`
                   return (
@@ -109,7 +109,7 @@ export function Sidebar({ isOpen, onToggle }: SidebarProps) {
                       <button
                         onClick={() => setActiveSection(`security-profile-${profile.id}`)}
                         className={cn(
-                          "w-full text-left px-3 py-2 rounded text-sm transition-colors",
+                          "w-full text-left px-2 py-1 rounded text-xs transition-colors",
                           isActive ? "bg-blue-600 text-white" : "hover:bg-gray-800 text-gray-400"
                         )}
                       >

--- a/frontend/src/components/tables/AddressesTable.tsx
+++ b/frontend/src/components/tables/AddressesTable.tsx
@@ -58,7 +58,7 @@ const AddressValueCell = React.memo(({ address }: { address: Address }) => {
   }
   
   return (
-    <code className={`text-sm px-2 py-1 rounded ${
+    <code className={`text-xs px-1 py-0.5 rounded ${
       value === 'N/A' 
         ? 'bg-red-100 text-red-700' 
         : 'bg-gray-100 text-gray-800'
@@ -76,7 +76,7 @@ const AddressLocationCell = React.memo(({ address }: { address: Address }) => {
                   address['parent-template'] || 
                   address['parent-vsys'] || 
                   'Shared'
-  return <span className="text-sm">{location}</span>
+  return <span className="text-xs">{location}</span>
 })
 
 AddressLocationCell.displayName = 'AddressLocationCell'
@@ -192,7 +192,7 @@ export function AddressesTable() {
         />
       ),
       cell: ({ row }) => (
-        <div className="font-medium">{row.getValue('name')}</div>
+        <div className="font-medium text-xs">{row.getValue('name')}</div>
       ),
     },
     {
@@ -211,7 +211,7 @@ export function AddressesTable() {
         />
       ),
       cell: ({ row }) => (
-        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
           {row.getValue('type')}
         </span>
       ),
@@ -262,9 +262,9 @@ export function AddressesTable() {
       cell: ({ row }) => {
         const description = row.getValue('description') as string
         return description ? (
-          <span className="text-gray-600 text-sm">{description}</span>
+          <span className="text-gray-600 text-xs">{description}</span>
         ) : (
-          <span className="text-gray-400 text-sm italic">No description</span>
+          <span className="text-gray-400 text-xs italic">No description</span>
         )
       },
     },
@@ -277,15 +277,15 @@ export function AddressesTable() {
         return (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="h-8 w-8 p-0">
+              <Button variant="ghost" className="h-6 w-6 p-0">
                 <span className="sr-only">Open menu</span>
-                <MoreHorizontal className="h-4 w-4" />
+                <MoreHorizontal className="h-3 w-3" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuLabel>Actions</DropdownMenuLabel>
               <DropdownMenuItem onClick={() => handleDetailView(address)}>
-                <Eye className="mr-2 h-4 w-4" />
+                <Eye className="mr-1 h-3 w-3" />
                 View details
               </DropdownMenuItem>
             </DropdownMenuContent>
@@ -298,13 +298,13 @@ export function AddressesTable() {
   // Show loading spinner when switching configs or initial load
   if (isLoading && isInitialLoad && !data) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[400px] space-y-4">
-        <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+      <div className="flex flex-col items-center justify-center min-h-[200px] space-y-2">
+        <Loader2 className="h-6 w-6 animate-spin text-blue-600" />
         <div className="text-center">
-          <p className="text-sm font-medium text-gray-900">
+          <p className="text-xs font-medium text-gray-900">
             Loading addresses...
           </p>
-          <p className="text-xs text-gray-500 mt-1">This may take a moment for large configurations</p>
+          <p className="text-xs text-gray-500">This may take a moment for large configurations</p>
         </div>
       </div>
     )
@@ -313,9 +313,9 @@ export function AddressesTable() {
   // Show error state
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[400px] space-y-4">
+      <div className="flex flex-col items-center justify-center min-h-[200px] space-y-2">
         <div className="text-center">
-          <p className="text-sm font-medium text-red-600">Error loading addresses</p>
+          <p className="text-xs font-medium text-red-600">Error loading addresses</p>
           <p className="text-xs text-gray-500 mt-1">{(error as Error).message}</p>
         </div>
       </div>
@@ -325,10 +325,10 @@ export function AddressesTable() {
 
   return (
     <>
-      <div className="space-y-4">
+      <div className="space-y-2">
         <div>
-          <h2 className="text-2xl font-bold tracking-tight">Addresses</h2>
-          <p className="text-muted-foreground">
+          <h2 className="text-lg font-bold tracking-tight">Addresses</h2>
+          <p className="text-xs text-muted-foreground">
             Manage network addresses and IP configurations
           </p>
         </div>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -20,10 +20,10 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: "h-8 px-3 py-1",
+        sm: "h-7 rounded-md px-2 text-xs",
+        lg: "h-9 rounded-md px-6",
+        icon: "h-8 w-8",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/data-table.tsx
+++ b/frontend/src/components/ui/data-table.tsx
@@ -100,13 +100,13 @@ export function DataTable<TData, TValue>({
   }
 
   return (
-    <div className="w-full space-y-4">
+    <div className="w-full space-y-2">
       <div className="flex items-center justify-end">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="outline" className="ml-auto">
-              <Settings2 className="mr-2 h-4 w-4" />
-              View <ChevronDown className="ml-2 h-4 w-4" />
+            <Button variant="outline" size="sm" className="ml-auto h-7 text-xs">
+              <Settings2 className="mr-1 h-3 w-3" />
+              View <ChevronDown className="ml-1 h-3 w-3" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
@@ -153,17 +153,17 @@ export function DataTable<TData, TValue>({
           <TableBody>
             {loading || data.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={columns.length} className="h-64 text-center">
+                <TableCell colSpan={columns.length} className="h-32 text-center">
                   {loading ? (
-                    <div className="flex flex-col items-center justify-center space-y-3">
-                      <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+                    <div className="flex flex-col items-center justify-center space-y-2">
+                      <Loader2 className="h-6 w-6 animate-spin text-blue-600" />
                       <div>
-                        <p className="text-sm font-medium text-gray-900">Loading data...</p>
-                        <p className="text-xs text-gray-500 mt-1">Applying filters and fetching results</p>
+                        <p className="text-xs font-medium text-gray-900">Loading data...</p>
+                        <p className="text-xs text-gray-500">Applying filters and fetching results</p>
                       </div>
                     </div>
                   ) : (
-                    <div className="text-gray-500">No results found</div>
+                    <div className="text-xs text-gray-500">No results found</div>
                   )}
                 </TableCell>
               </TableRow>
@@ -184,14 +184,14 @@ export function DataTable<TData, TValue>({
           </TableBody>
         </Table>
       </div>
-      <div className="flex items-center justify-between space-x-2 py-4">
+      <div className="flex items-center justify-between space-x-2 py-2">
         <div className="flex items-center space-x-2">
-          <span className="text-sm text-muted-foreground">Rows per page:</span>
+          <span className="text-xs text-muted-foreground">Rows per page:</span>
           <Select
             value={pagination?.pageSize?.toString() ?? "100"}
             onValueChange={handlePageSizeChange}
           >
-            <SelectTrigger className="w-16 h-8">
+            <SelectTrigger className="w-14 h-7 text-xs">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -204,7 +204,7 @@ export function DataTable<TData, TValue>({
           </Select>
         </div>
         <div className="flex items-center space-x-2">
-          <span className="text-sm text-muted-foreground">
+          <span className="text-xs text-muted-foreground">
             Showing {((pagination?.pageIndex ?? 0) * (pagination?.pageSize ?? 100)) + 1} to{" "}
             {Math.min(
               ((pagination?.pageIndex ?? 0) + 1) * (pagination?.pageSize ?? 100),
@@ -223,7 +223,7 @@ export function DataTable<TData, TValue>({
             Previous
           </Button>
           <div className="flex items-center gap-1">
-            <span className="text-sm">
+            <span className="text-xs">
               Page {(pagination?.pageIndex ?? 0) + 1} of {pageCount ?? 1}
             </span>
           </div>

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -9,7 +9,7 @@ const Table = React.forwardRef<
   <div className="relative w-full overflow-auto">
     <table
       ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
+      className={cn("w-full caption-bottom text-xs", className)}
       {...props}
     />
   </div>
@@ -73,7 +73,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      "h-8 px-2 text-left align-middle font-medium text-muted-foreground text-xs [&:has([role=checkbox])]:pr-0",
       className
     )}
     {...props}
@@ -87,7 +87,7 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    className={cn("py-1 px-2 align-middle text-xs [&:has([role=checkbox])]:pr-0", className)}
     {...props}
   />
 ))
@@ -99,7 +99,7 @@ const TableCaption = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    className={cn("mt-2 text-xs text-muted-foreground", className)}
     {...props}
   />
 ))

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -54,6 +54,15 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground text-sm;
   }
+  
+  /* Reduce default font sizes */
+  h1 { @apply text-xl; }
+  h2 { @apply text-lg; }
+  h3 { @apply text-base; }
+  p { @apply text-sm; }
+  
+  /* Make tables more compact */
+  table { @apply text-xs; }
 }


### PR DESCRIPTION
- Reduced global font sizes (text-xs for tables, text-sm for body)
- Decreased padding/margins in table cells (py-1 px-2 instead of p-4)
- Made table headers more compact (h-8 instead of h-12)
- Reduced button sizes and icon dimensions
- Compacted sidebar navigation with smaller spacing
- Shrunk header height and font sizes
- Updated all table components for consistent compact styling
- More data now visible on screen without scrolling

🤖 Generated with Claude Code